### PR TITLE
[WIP] Enemy HP bar

### DIFF
--- a/Crystalis.st
+++ b/Crystalis.st
@@ -43229,6 +43229,8 @@ LoadPalettesForLocation
         ;; Prepares a write of palettes indexed by $7e0..$7e7.
         $34c0e  xx xx:      xxx #$xx
         $34c10  xx xx:      xxx $xx
+LoadPalettesForCustomLocation
+        ;; When changing screens, some will set $11 before jmping straight to this location
         $34c12  xx xx:      xxx $xx
         $34c14  xx:         xxx
         $34c15  xx:          xxx
@@ -43271,8 +43273,8 @@ LoadPalettesForLocation
         $34c55  xx xx:      xxx $xx
 -       $34c57  xx xx:      xxx $xx
         $34c59  xx:         xxx
-        $34c5a  xx xx xx:   xxx $3c176
-        $34c5d  xx xx xx:   xxx $34c12
+        $34c5a  xx xx xx:   xxx WaitForMultipleOAMDMA
+        $34c5d  xx xx xx:   xxx LoadPalettesForCustomLocation
         $34c60  xx xx:      xxx $xx
         $34c62  xx:         xxx
         $34c63  xx xx:      xxx $xx
@@ -46388,7 +46390,7 @@ DataTable_362ac
 ;;; This is called by $3cd28 using $4a0,x:7f as the index.
 ;;; Note that entries $60..$6f are on a different page.
 ;;; STRIP: word=$2c000
-ObjectActionJumpTable
+ Table
         $36314              .word ($xxxx)
         $36316              .word ($35b45) ; 01
         $36318              .word ($35d81) ; 02
@@ -60654,13 +60656,16 @@ FallIntoPit
         $3e60c  xx xx:      xxx #$xx
         $3e60e  xx xx xx:   xxx $34c49
 ;;; --------------------------------
+ClearAllObjectsOnLocationChange
         $3e611  xx xx:      xxx #$xx ; 34000 -> 8000
         $3e613  xx xx xx:   xxx BankSwitch8k_8000
+        ;; This seems to load a specific palette?
         $3e616  xx xx:      xxx #$xx
         $3e618  xx xx xx:   xxx $34c3d
+        ;; Loops through all the objects and writes 0 to the ObjectActionScript
         $3e61b  xx xx:      xxx #$xx
         $3e61d  xx xx:      xxx #$xx
--       $3e61f  xx xx xx:   xxx $xxxx,x
+-       $3e61f  xx xx xx:   xxx ObjectActionScript,x
         $3e622  xx:         xxx
         $3e623  xx xx:      xxx #$xx
         $3e625  xx xx:      xxx - ; $3e61f

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,8 @@ gulp.task('buildchr', function() {
               .join('\n  ');
               
             
-            out += `public static readonly ${file.stem}_tile${start} = parsePattern(\`\n  ${concatted}\n\`);\n`;
+            const tile_as_hex = Number(start).toString(16).padStart(2, '0')
+            out += `public static readonly ${file.stem}_tile${tile_as_hex} = parsePattern(\`\n  ${concatted}\n\`);\n`;
             ++start;
           }
         }

--- a/src/js/init.s
+++ b/src/js/init.s
@@ -81,6 +81,7 @@ ObjectExp = $520
 ; starting at zero and counting up to ExpToNextLevel, it will start at ExpToNextLevel
 ; and count down.
 PlayerExp = $704
+LastAttackedEnemyOffset = $706 ; replaces PlayerMaxExp
 PlayerMP = $708
 PlayerMaxMP = $709
 EquippedConsumableItem = $715
@@ -100,6 +101,9 @@ ShouldRedisplayDifficulty = $61ff
         
 SelectedConsumableIndex = $642c
 SelectedQuestItemIndex  = $642e
+
+ObjectMaxHPLo = $6a00
+ObjectMaxHPHi = $6a20
 
 .ifdef _EXTRA_PITY_MP
 PITY_MP_AMOUNT    = 34

--- a/src/js/pass/deterministic.ts
+++ b/src/js/pass/deterministic.ts
@@ -157,6 +157,8 @@ export function deterministic(rom: Rom, flags: FlagSet): void {
 
   useNewStatusBarGraphics(rom);
 
+  useEnemyHPBarGraphics(rom);
+
 }
 
 // Updates a few itemuse and trigger actions in light of consolidation
@@ -170,6 +172,25 @@ function useNewStatusBarGraphics(rom: Rom): void {
   rom.patterns.set(page, 0x4, Patterns.HUD_DL);
   rom.patterns.set(page, 0x5, Patterns.HUD_MP);
   rom.patterns.set(page, 0x6, Patterns.HUD_EX);
+}
+
+// Replaces some unused tiles with custom HP bar tiles
+// NOTE: This needs the new status bar patch applied to free up tiles
+function useEnemyHPBarGraphics(rom: Rom): void {
+  const page = 0x38 << 6
+  rom.patterns.set(page, 0x07, Patterns.HP_END_1TICK);
+  rom.patterns.set(page, 0x1a, Patterns.HP_END_2TICK);
+  rom.patterns.set(page, 0x1b, Patterns.HP_END_3TICK);
+  rom.patterns.set(page, 0x68, Patterns.HP_END_2TICK_OUTOF_3);
+  rom.patterns.set(page, 0x69, Patterns.HP_END_1TICK_OUTOF_3);
+  rom.patterns.set(page, 0x6a, Patterns.HP_END_0TICK_OUTOF_3);
+  rom.patterns.set(page, 0x6b, Patterns.HP_END_1TICK_OUTOF_2);
+  rom.patterns.set(page, 0x6c, Patterns.HP_END_0TICK_OUTOF_2);
+  rom.patterns.set(page, 0x6d, Patterns.HP_END_0TICK_OUTOF_1);
+  rom.patterns.set(page, 0x71, Patterns.SECOND_BAR_4TICK);
+  rom.patterns.set(page, 0x72, Patterns.SECOND_BAR_3TICK);
+  rom.patterns.set(page, 0x73, Patterns.SECOND_BAR_2TICK);
+  rom.patterns.set(page, 0x74, Patterns.SECOND_BAR_1TICK);
 }
 
 // Updates a few itemuse and trigger actions in light of consolidation

--- a/src/js/postshuffle.s
+++ b/src/js/postshuffle.s
@@ -142,6 +142,12 @@ RescaleDefAndHP:
     sec
 +  rol ObjectDef,x
    sta ObjectHP,x
+   ;; Store the calculated Max HP into a different RAM location
+   ;; for the enemy HP bar calculations
+   sta ObjectMaxHPLo,x
+   lda ObjectDef,x
+   and #$01
+   sta ObjectMaxHPHi,x
 RescaleAtk:   ; $1bc63
   ;; DiffDef = 4 * PDef
   ;; DiffHP = PHP

--- a/src/js/rom/pattern.ts
+++ b/src/js/rom/pattern.ts
@@ -132,6 +132,142 @@ export class Patterns implements Iterable<Pattern> {
     xxxx+o+o
     xxxxxoxo
   `);
+  
+  // Custom end size for the HP bar (with 1, 2 and 3 extra bits)
+  public static readonly HP_END_1TICK = parsePattern(`
+    ooooxxxx
+    +o+oxxxx
+    xo+oxxxx
+    +o+oxxxx
+    xo+oxxxx
+    xo+oxxxx
+    ooooxxxx
+    xxxxxxxx
+  `);
+  public static readonly HP_END_2TICK = parsePattern(`
+    ooooooxx
+    +o+o+oxx
+    xoxo+oxx
+    +o+o+oxx
+    xoxo+oxx
+    xoxo+oxx
+    ooooooxx
+    xxxxxxxx
+  `);
+  public static readonly HP_END_3TICK = parsePattern(`
+    oooooooo
+    +o+o+o+o
+    xoxoxo+o
+    +o+o+o+o
+    xoxoxo+o
+    xoxoxo+o
+    oooooooo
+    xxxxxxxx
+  `);
+
+  // Extra bar ends for when the target is missing some hp
+  public static readonly HP_END_2TICK_OUTOF_3 = parsePattern(`
+    oooooooo
+    +o+o+++o
+    xoxooo+o
+    +o+ooo+o
+    xoxooo+o
+    xoxo+++o
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly HP_END_1TICK_OUTOF_3 = parsePattern(`
+    oooooooo
+    +o+++++o
+    xooooo+o
+    +ooooo+o
+    xooooo+o
+    xo+++++o
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly HP_END_0TICK_OUTOF_3 = parsePattern(`
+    oooooooo
+    +++++++o
+    oooooo+o
+    oooooo+o
+    oooooo+o
+    +++++++o
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly HP_END_1TICK_OUTOF_2 = parsePattern(`
+    ooooooxx
+    +o+++oxx
+    xooo+oxx
+    +ooo+oxx
+    xooo+oxx
+    xo+++oxx
+    ooooooxx
+    xxxxxxxx
+  `);
+  public static readonly HP_END_0TICK_OUTOF_2 = parsePattern(`
+    ooooooxx
+    +++++oxx
+    oooo+oxx
+    oooo+oxx
+    oooo+oxx
+    +++++oxx
+    ooooooxx
+    xxxxxxxx
+  `);
+  public static readonly HP_END_0TICK_OUTOF_1 = parsePattern(`
+    ooooxxxx
+    +++oxxxx
+    oo+oxxxx
+    oo+oxxxx
+    oo+oxxxx
+    +++oxxxx
+    ooooxxxx
+    xxxxxxxx
+  `);
+
+  // Custom "black bar" HP bar for displaying hp > 255
+  public static readonly SECOND_BAR_4TICK = parsePattern(`
+    oooooooo
+    +o+o+o+o
+    oooooooo
+    +o+o+o+o
+    oooooooo
+    oooooooo
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly SECOND_BAR_3TICK = parsePattern(`
+    oooooooo
+    +o+o+o+o
+    ooooooxo
+    +o+o+o+o
+    ooooooxo
+    ooooooxo
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly SECOND_BAR_2TICK = parsePattern(`
+    oooooooo
+    +o+o+o+o
+    ooooxoxo
+    +o+o+o+o
+    ooooxoxo
+    ooooxoxo
+    oooooooo
+    xxxxxxxx
+  `);
+  public static readonly SECOND_BAR_1TICK = parsePattern(`
+    oooooooo
+    +o+o+o+o
+    ooxoxoxo
+    +o+o+o+o
+    ooxoxoxo
+    ooxoxoxo
+    oooooooo
+    xxxxxxxx
+  `);
 }
 
 function parsePattern(data: String) : number[] {


### PR DESCRIPTION
Based off the UI changes I've made, this change adds an Enemy HP Bar for the last attacked enemy.

The code is currently a spaghetti mess. Turns out its really complicated to add this, so it may not be worth reviewing until I get a change to clean it up. I'm opening a Draft Pull Request now since its getting close to being ready, and if you wanted a general idea of what the code will be like and have some time to look it over, I feel I might as well open the PR early then.

TODO List:
Features:
- [x] Base enemy HP bar for last attacked enemy.
- [ ] Auto hide on area change.
- [ ] Auto hide on enemy despawn
- [ ] Hide HP bar after enemy dies
- [ ] Hide HP bar after a certain time limit. (Maybe don't need?)

Bug fixes:
- [ ] Certain combinations of HP/Max HP are displayed incorrectly so the enemy HP sometimes partially "refills".
- [ ] HP above 255 may not work properly (needs more testing)
- [ ] Probably more when mattrick gets his hands on it.