### PR TITLE
Refactor NMI and make it relocatable

### DIFF
--- a/Crystalis.st
+++ b/Crystalis.st
@@ -26869,7 +26869,7 @@ DataTable_1fb8f
 ;;; --------------------------------
 DisplayStartMenu
 MainGameModeJump_0c
-        $1fc40  xx xx:      xxx $xx
+        $1fc40  xx xx:      xxx ScreenMode
         $1fc42  xx:         xxx
         $1fc43  xx xx xx:   xxx WaitForNametableFlush
         $1fc46  xx xx xx:   xxx WaitForOAMDMA
@@ -30770,6 +30770,7 @@ MainLoop_PrepareEndingSequence
         $220e8  xx xx:      xxx $xx
         $220ea  xx:         xxx
 ;;; --------------------------------
+        ; Countdown for ending credits
         $220eb  xx xx xx:   xxx $xxxx
         $220ee  xx xx:      xxx $xx
         $220f0  xx:         xxx
@@ -30780,6 +30781,7 @@ MainLoop_PrepareEndingSequence
         $220f9  xx xx:      xxx $xx
         $220fb  xx:         xxx
 ;;; --------------------------------
+        ; $0600 seems to store the stage of the credits. $1c is "THE END" appears?
         $220fc  xx xx xx:   xxx $xxxx
         $220ff  xx:         xxx
 ;;; --------------------------------
@@ -31475,6 +31477,7 @@ DataTable_2265e
         $22717  xx xx xx:   xxx $xxxx
         $2271a  xx:         xxx
 ;;; --------------------------------
+EndingCreditsFinished
         $2271b  xx:         xxx
 ;;; --------------------------------
 DataTable_2271c
@@ -31845,6 +31848,7 @@ DataTable_2271c
         $229d1  xx xx xx:   xxx $xxxx,x
         $229d4  xx xx xx:   xxx $22967
 ;;; --------------------------------
+WriteTheEndOAMData
         $229d7  xx:         xxx
         $229d8  xx:         xxx
         $229d9  xx xx:      xxx #$xx
@@ -31863,6 +31867,7 @@ DataTable_2271c
         $229f7  xx xx:      xxx $xx
         $229f9  xx:         xxx
 ;;; --------------------------------
+WriteTheEndOAMDataCopyLoop
         $229fa  xx xx xx:   xxx $xxxx,x
         $229fd  xx:         xxx
         $229fe  xx xx:      xxx ($xx),y
@@ -32458,18 +32463,18 @@ AnimateSNKLogo
         $24080  xx xx:      xxx #$xx
         $24082  xx xx:      xxx $xx
         $24084  xx xx xx:   xxx EnableNMI_alt2
-        $24087  xx xx xx:   xxx WaitForNMI_alt2
+        $24087  xx xx xx:   xxx WaitForOAMDMA_alt2
         $2408a  xx xx:      xxx #$xx
         $2408c  xx xx xx:   xxx $242be
         $2408f  xx xx:      xxx #$xx
         $24091  xx xx xx:   xxx $242be
         $24094  xx xx xx:   xxx $242fd
--       $24097  xx xx xx:    xxx $24198
+-       $24097  xx xx xx:    xxx WaitForOAMDMA_alt2
         $2409a  xx xx xx:    xxx $xxxx
         $2409d  xx xx xx:    xxx $24310
         $240a0  xx xx xx:    xxx $xxxx
         $240a3  xx xx:      xxx - ; $24097
--       $240a5  xx xx xx:     xxx $24198
+-       $240a5  xx xx xx:     xxx WaitForOAMDMA_alt2
         $240a8  xx xx xx:     xxx $xxxx
         $240ab  xx xx xx:     xxx $xxxx
         $240ae  xx xx:        xxx #$xx
@@ -32483,11 +32488,11 @@ AnimateSNKLogo
         $240be  xx xx:      xxx $xx
         $240c0  xx xx:      xxx #$xx
         $240c2  xx xx xx:   xxx $xxxx
--       $240c5  xx xx xx:    xxx $24198
+-       $240c5  xx xx xx:    xxx WaitForOAMDMA_alt2
         $240c8  xx xx xx:    xxx $xxxx
         $240cb  xx xx:      xxx - ; $240c5
         $240cd  xx xx xx:   xxx TitleScreenFadeOut
--       $240d0  xx xx xx:    xxx $24198
+-       $240d0  xx xx xx:    xxx WaitForOAMDMA_alt2
         $240d3  xx xx xx:    xxx $xxxx
         $240d6  xx xx xx:    xxx $2434a
         $240d9  xx xx xx:    xxx $xxxx
@@ -32600,7 +32605,7 @@ EnableSpritesAndLeftColumnRendering
         $24195  xx xx:      xxx $xx
         $24197  xx:         xxx
 ;;; --------------------------------
-WaitForNMI_alt2
+WaitForOAMDMA_alt2
 -       $24198  xx xx:       xxx $xx
         $2419a  xx xx:      xxx - ; $24198
         $2419c  xx xx:      xxx #$xx
@@ -32730,7 +32735,7 @@ WriteRectangleToNametable
         $2425d  xx xx:      xxx $xx
         $2425f  xx xx:      xxx #$xx
         $24261  xx xx:      xxx $xx
-        $24263  xx xx xx:   xxx $24174
+        $24263  xx xx xx:   xxx DisableNMI_alt2
         $24266  xx xx:      xxx #$xx
         $24268  xx xx:      xxx $xx
         $2426a  xx xx:      xxx ($xx),y
@@ -32765,8 +32770,8 @@ WriteRectangleToNametable
         $242a2  xx xx:      xxx #$xx
         $242a4  xx xx:      xxx #$xx
         $242a6  xx xx:      xxx $xx
-        $242a8  xx xx xx:   xxx $2417c
-        $242ab  xx xx xx:   xxx $24198
+        $242a8  xx xx xx:   xxx EnableNMI_alt2
+        $242ab  xx xx xx:   xxx WaitForOAMDMA_alt2
         $242ae  xx xx:      xxx $xx
         $242b0  xx xx:      xxx $xx
         $242b2  xx:         xxx
@@ -33404,7 +33409,7 @@ TitleScreen00SubJump_Delay
 MainLoop_PrepareTitleScreen
         $25fcc  xx xx xx:   xxx $242b3
         $25fcf  xx xx xx:   xxx $241d8
-        $25fd2  xx xx xx:   xxx $24198
+        $25fd2  xx xx xx:   xxx WaitForOAMDMA_alt2
         $25fd5  xx xx:      xxx #SCREEN_MODE_MOVIE
         $25fd7  xx xx:      xxx ScreenMode
         $25fd9  xx xx:      xxx #$xx
@@ -33511,14 +33516,18 @@ TitleMovieFlushSound
         $2608e  xx xx xx:   xxx $xxxx
         $26091  xx:         xxx
 ;;; --------------------------------
-        $26092  xx xx:      xxx $xx
+ResetNMTBuffer
+; Waits for NMT write buffer to empty, then resets the index
+; to zero. They do this because they want to write two entries
+; without bumping the pointer twice. :shrug:
+-       $26092  xx xx:      xxx $xx
         $26094  xx xx:      xxx $xx
-        $26096  xx xx:      xxx $xx
-        $26098  xx xx xx:   xxx $24174
+        $26096  xx xx:      xxx -
+        $26098  xx xx xx:   xxx DisableNMI_alt2
         $2609b  xx xx:      xxx #$xx
         $2609d  xx xx:      xxx $xx
         $2609f  xx xx:      xxx $xx
-        $260a1  xx xx xx:   xxx $2417c
+        $260a1  xx xx xx:   xxx EnableNMI_alt2
         $260a4  xx:         xxx
 ;;; --------------------------------
         $260a5  xx xx:      xxx $xx
@@ -33539,7 +33548,7 @@ TitleMovieJump_3                ; Preparing computer (6f0=3)
         $260b7  xx xx xx:   xxx $xxxx
         $260ba  xx xx xx:   xxx $242b3
         $260bd  xx xx xx:   xxx $241d8
-        $260c0  xx xx xx:   xxx $24198
+        $260c0  xx xx xx:   xxx WaitForOAMDMA_alt2
         $260c3  xx xx:      xxx #$xx
         $260c5  xx xx:      xxx $xx
         $260c7  xx xx:      xxx $xx
@@ -33776,8 +33785,8 @@ DataTable_26193
         $262d3  xx xx:      xxx $xx
         $262d5  xx xx:      xxx #SFX_COMPUTER_PROMPT
         $262d7  xx xx xx:   xxx $xxxx
-        $262da  xx xx xx:   xxx $26092
-        $262dd  xx xx xx:   xxx $24174
+        $262da  xx xx xx:   xxx ResetNMTBuffer
+        $262dd  xx xx xx:   xxx DisableNMI_alt2
         $262e0  xx xx:      xxx $xx
         $262e2  xx xx:      xxx $xx
         $262e4  xx xx xx:   xxx $xxxx,x
@@ -33797,10 +33806,10 @@ DataTable_26193
         $26305  xx xx:      xxx #$xx
         $26307  xx xx:      xxx #$xx
         $26309  xx xx:      xxx $xx
-        $2630b  xx xx xx:   xxx $2417c
-        $2630e  xx xx xx:   xxx $24198
-        $26311  xx xx xx:   xxx $26092
-        $26314  xx xx xx:   xxx $24174
+        $2630b  xx xx xx:   xxx EnableNMI_alt2
+        $2630e  xx xx xx:   xxx WaitForOAMDMA_alt2
+        $26311  xx xx xx:   xxx ResetNMTBuffer
+        $26314  xx xx xx:   xxx DisableNMI_alt2
         $26317  xx xx:      xxx $xx
         $26319  xx xx:      xxx $xx
         $2631b  xx:         xxx
@@ -33822,7 +33831,7 @@ DataTable_26193
         $2633f  xx xx:      xxx #$xx
         $26341  xx xx:      xxx #$xx
         $26343  xx xx:      xxx $xx
-        $26345  xx xx xx:   xxx $2417c
+        $26345  xx xx xx:   xxx EnableNMI_alt2
         $26348  xx:         xxx
 ;;; --------------------------------
 DataTable_26349
@@ -33860,8 +33869,8 @@ DataTable_26349
         $26365  xx xx xx:   xxx $xxxx
         $26368  xx:         xxx
         $26369  xx xx:      xxx $xx
-        $2636b  xx xx xx:   xxx $26092
-        $2636e  xx xx xx:   xxx $24174
+        $2636b  xx xx xx:   xxx ResetNMTBuffer
+        $2636e  xx xx xx:   xxx DisableNMI_alt2
         $26371  xx xx:      xxx $xx
         $26373  xx xx:      xxx $xx
         $26375  xx xx:      xxx #$xx
@@ -33883,7 +33892,7 @@ DataTable_26349
         $2639a  xx xx:      xxx #$xx
         $2639c  xx xx:      xxx $xx
         $2639e  xx xx:      xxx $xx
-        $263a0  xx xx xx:   xxx $2417c
+        $263a0  xx xx xx:   xxx EnableNMI_alt2
         $263a3  xx xx:      xxx #$xx
         $263a5  xx xx xx:   xxx $xxxx
         $263a8  xx xx xx:   xxx $xxxx
@@ -33991,8 +34000,8 @@ DataTable_26349
         $26473  xx xx:      xxx #$xx
         $26475  xx xx xx:   xxx $264b2
         $26478  xx xx:      xxx $xx
-        $2647a  xx xx xx:   xxx $26092
-        $2647d  xx xx xx:   xxx $24174
+        $2647a  xx xx xx:   xxx ResetNMTBuffer
+        $2647d  xx xx xx:   xxx DisableNMI_alt2
         $26480  xx xx:      xxx $xx
         $26482  xx xx:      xxx $xx
         $26484  xx xx:      xxx #$xx
@@ -34013,7 +34022,7 @@ DataTable_26349
         $264a7  xx xx:      xxx #$xx
         $264a9  xx xx:      xxx #$xx
         $264ab  xx xx:      xxx $xx
-        $264ad  xx xx xx:   xxx $2417c
+        $264ad  xx xx xx:   xxx EnableNMI_alt2
         $264b0  xx:         xxx
 ;;; --------------------------------
 DataTable_264b1
@@ -34122,14 +34131,14 @@ DataTable_264b1
 ;;; --------------------------------
 DataTableAddress_2656e
         $2656c              .word (DataTable_2656e) ; $a56e
-DataTable_2656e 
+DataTable_2656e
         ;; Default player name (stored in $6418)
         $2656e              .byte "xxxxxx",$xx
         ;; Secondary name or maybe placeholder (stored in $6410)
         $26575              .byte "xxxxxx",$xx
 ;;; --------------------------------
         $2657c  xx xx xx:   xxx $242b3
-        $2657f  xx xx xx:   xxx $24198
+        $2657f  xx xx xx:   xxx WaitForOAMDMA_alt2
         $26582  xx xx xx:   xxx $266f9
 ;;; --------------------------------
         $26585  xx xx:      xxx $xx
@@ -34237,7 +34246,7 @@ DataTable_2656e
 ;;; --------------------------------
 TitleMovieJump_5                ; Preparing main title menu (6f0=5)
         $26653  xx xx xx:   xxx $242b3
-        $26656  xx xx xx:   xxx $24198
+        $26656  xx xx xx:   xxx WaitForOAMDMA_alt2
         $26659  xx xx:      xxx #$xx
         $2665b  xx xx:      xxx #$xx
         $2665d  xx xx:      xxx #$xx
@@ -34261,7 +34270,7 @@ TitleMovieJump_5                ; Preparing main title menu (6f0=5)
         $26689  xx xx:      xxx #$xx
         $2668b  xx xx:      xxx $xx
         $2668d  xx xx xx:   xxx $241d8
-        $26690  xx xx xx:   xxx $24198
+        $26690  xx xx xx:   xxx WaitForOAMDMA_alt2
         $26693  xx xx:      xxx #$xx
         $26695  xx xx xx:   xxx $xxxx
         $26698  xx xx xx:   xxx $254be
@@ -34404,7 +34413,7 @@ TitleMenuHandleStart
 ;;; --------------------------------
         $26796  xx xx:      xxx $xx
         $26798  xx xx xx:   xxx $242b3
-        $2679b  xx xx xx:   xxx $24198
+        $2679b  xx xx xx:   xxx WaitForOAMDMA_alt2
         $2679e  xx:         xxx
 ;;; --------------------------------
 TitleMovieJump_0                ; Main looping title movie (6f0=0)
@@ -34656,7 +34665,7 @@ TitleLoopSceneJump_0b
         $269a9  xx xx:      xxx #$xx
         $269ab  xx xx:      xxx $xx
         $269ad  xx xx xx:   xxx $241f0
-        $269b0  xx xx xx:   xxx $24198
+        $269b0  xx xx xx:   xxx WaitForOAMDMA_alt2
         $269b3  xx xx:      xxx #$xx
         $269b5  xx xx:      xxx #$xx
         $269b7  xx xx:      xxx #$xx
@@ -34902,7 +34911,7 @@ TitleLoopSceneJump_18
 ;;; --------------------------------
 TitleMovieJump_1                ; Switching to intro movie (6f0=1)
         $26bb4  xx xx xx:   xxx ClearMapPaletteSpace
-        $26bb7  xx xx xx:   xxx WaitForNMI_alt2
+        $26bb7  xx xx xx:   xxx WaitForOAMDMA_alt2
         $26bba  xx xx:      xxx #SCREEN_MODE_MOVIE
         $26bbc  xx xx:      xxx ScreenMode
         $26bbe  xx xx:      xxx #$xx
@@ -41446,6 +41455,7 @@ AudioJumpTable_7X
         $304ac  xx xx:      xxx $xx
         $304ae  xx:         xxx
 ;;; --------------------------------
+AudioOutputVolume
         $304af  xx xx xx:   xxx $xxxx,x
         $304b2  xx xx:      xxx ++++ ; $304f0
 -       $304b4  xx xx xx:   xxx $xxxx,x
@@ -41514,44 +41524,63 @@ AudioJumpTable_7X
         $3052e  xx xx xx:   xxx $xxxx,y
         $30531  xx:         xxx
 ;;; --------------------------------
-;;; Sets the volume (or envelope info)
+;;; Sets the volume max (used as a lookup in the volume table with the envelope)
 AudioJumpTable_8X
         $30532  xx xx:      xxx $xx
-        $30534  xx xx:      xxx $xx
+        $30534  xx xx:      xxx + ; $3054c
+        ; The 8x command is in $f3, so remove the `8` (upper 4 bits)
         $30536  xx xx:      xxx $xx
         $30538  xx xx:      xxx #$xx
         $3053a  xx xx:      xxx $xx
+        ; now $f3 has just the new volume max setting,
+        ; write the new max to $168
         $3053c  xx xx xx:   xxx $xxxx,x
         $3053f  xx xx:      xxx #$xx
         $30541  xx xx:      xxx $xx
         $30543  xx xx xx:   xxx $xxxx,x
+        ; Mark that a new volume max was set?
         $30546  xx xx:      xxx #$xx
         $30548  xx xx:      xxx $xx
         $3054a  xx xx:      xxx $xx
-        $3054c  xx:         xxx
++       $3054c  xx:         xxx
 ;;; --------------------------------
 AudioJumpTable_9X
+; Seems to set the volume with a different mechanism than the eX command
+        ; Load which instrument we are into y
         $3054d  xx xx xx:   xxx $307a6,x
+        ; original bits look like abcd efgh
         $30550  xx xx:      xxx $xx
         $30552  xx:         xxx
         $30553  xx:         xxx
         $30554  xx:         xxx
         $30555  xx:         xxx
+        ; now we have a = efgh 0000 ie: command value bits in the upper 4 bits
+        ; if this is for the triangle channel
         $30556  xx xx:      xxx #$xx
         $30558  xx xx:      xxx ++ ; $30571
+        ; otherwise (its for square or noise etc)
         $3055a  xx:          xxx
+        ; write only the lowest bit ( bit h ) back to $f3
         $3055b  xx xx:        xxx #$xx
         $3055d  xx xx:        xxx $xx
         $3055f  xx xx:        xxx + ; $30569
+        ; if the command value is even (bit h == 1)
+        ; Disable volume envelope (sets bit 6 to 0) because $#bf == ~$#40
         $30561  xx xx xx:      xxx $xxxx,x
         $30564  xx xx:         xxx #$xx
         $30566  xx xx xx:      xxx $xxxx,x
 +       $30569  xx:          xxx
         $3056a  xx:          xxx
+        ; only 3 bits at this point remain (bits fgh the lowest of command bits)
+        ; bit 4 was used to disable volume envelope. Now we drop that one so we only have
+        ; two bits left of the command value. gh00 0000
         $3056b  xx xx:       xxx #$xx
+        ; or it with low bit of $f3 (so now we have gh0h)
         $3056d  xx xx:       xxx $xx
+        ; and always set the 5th bit (gh1h 0000)
         $3056f  xx xx:       xxx #$xx
 ++      $30571  xx xx:      xxx $xx
+        ; set the upper 4 bits of $0168 and flag volume changed
         $30573  xx xx xx:   xxx $xxxx,x
         $30576  xx xx:      xxx #$xx
         $30578  xx xx:      xxx $xx
@@ -41636,12 +41665,14 @@ Add6ToX
         $305f6  xx:         xxx
 ;;; --------------------------------
 AudioJumpTable_eX
+        ; Write the specific envelope into the upper 4 bits of $15c
         $305f7  xx xx:      xxx $xx
         $305f9  xx:         xxx
         $305fa  xx:         xxx
         $305fb  xx:         xxx
         $305fc  xx:         xxx
         $305fd  xx xx xx:   xxx $xxxx,x
+        ; set flag in $114 to denote that this has a volume envelope
         $30600  xx xx xx:   xxx $xxxx,x
         $30603  xx xx:      xxx #$xx
         $30605  xx xx xx:   xxx $xxxx,x
@@ -41744,6 +41775,7 @@ AudioJumpTable_fX
         $306a6  xx xx xx:   xxx $xxxx,x
         $306a9  xx:         xxx
 ;;; --------------------------------
+AudioOutputTimer
         $306aa  xx xx xx:   xxx $xxxx,x
         $306ad  xx xx:      xxx ++ ; $30713
         $306af  xx xx:      xxx #$xx
@@ -41777,7 +41809,7 @@ AudioJumpTable_fX
         $306e8  xx xx xx:   xxx $30714,y
         $306eb  xx xx:      xxx + ; $306f6
         $306ed  xx:         xxx
-        $306ee  xx xx:      xxx #$xx
+        $306ee  xx xx:      xxx #$xx ; subtracts two
         $306f0  xx xx xx:   xxx $xxxx,x
         $306f3  xx:         xxx
         $306f4  xx xx:      xxx #$xx
@@ -41795,10 +41827,11 @@ AudioJumpTable_fX
         $30710  xx xx xx:   xxx $xxxx,y
 ++      $30713  xx:         xxx
 ;;; --------------------------------
-DataTable_30714 
+EvenOnlyMaskTableMaybe
         $30714              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
 ;;; --------------------------------
 ;;; This table seems to be used by the fX audio opcodes
+PitchEnvelopeTable
         $30724              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $30734              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $30744              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
@@ -41853,6 +41886,7 @@ AudioPitchTableHi
         $30898              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $308a8              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
 ;;; --------------------------------
+AudioVolumeEnvelopeTable
         $308b8              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $308c0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $308d0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
@@ -41871,6 +41905,7 @@ AudioPitchTableHi
         $309a0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $309b0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
 ;;; --------------------------------
+AudioVolumeEnvelopeForSquare2Table
         $309b8              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $309c0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $309d0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
@@ -41896,6 +41931,10 @@ AudioDelayTable
         $30ac8              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $30ad0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
 ;;; --------------------------------
+;;; Quick lookup table to convert from full 8 bit volume number to a 4 bit volume used by NES
+;;; This is a table that calculates max(1, a + b - 16) unless a or b are 0 (then its 0)
+;;; where a = value in and b = (offset >> 4)
+AudioVolumeLookupTable
         $30ad8              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $30ae0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
         $30af0              .byte $xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx,$xx
@@ -43974,7 +44013,7 @@ UpdateHPDisplayInternal
         $34d41  xx xx xx:     xxx ImmediateWriteNametableDataToPpu
 +       $34d44  xx:         xxx
         $34d45  xx:         xxx
-        $34d46  xx xx xx:   xxx $3c436
+        $34d46  xx xx xx:   xxx EnableNMI
 ;;; --------------------------------
 HPDisplayTileLookup
         ;; Each tile represents 16 HP, this is the mapping for currentHp % 16
@@ -44050,8 +44089,8 @@ ChargeIndicatorDisplay
         $34dce  xx xx:       xxx $xx
         $34dd0  xx xx:       xxx #$xx
         $34dd2  xx xx:       xxx $xx
-        $34dd4  xx xx xx:    xxx $3c8b2
-        $34dd7  xx xx xx:    xxx $3c436
+        $34dd4  xx xx xx:    xxx ImmediateWriteNametableDataToPpu
+        $34dd7  xx xx xx:    xxx EnableNMI
         $34dda  xx:         xxx
         $34ddb  xx:         xxx
         $34ddc  xx:         xxx
@@ -57027,7 +57066,7 @@ WriteNametableDataToPpu
         ;; This looks like it's doing some sort of run-length encoding?
         $3c6a0  xx xx xx:   xxx $xxxx,x
         $3c6a3  xx xx:      xxx $xx
--       $3c6a5  xx xx xx:   xxx $xxxx,x
+        $3c6a5  xx xx xx:   xxx $xxxx,x
         ;; Mark this buffer as clear. If bit 7 of $6202 is set, then
         ;; write from the memory in $6100 instead
         $3c6a8  xx xx:      xxx #$xx
@@ -57282,7 +57321,7 @@ LoadMapData_A
         $3c861  xx xx:      xxx + ; $3c864
         $3c863  xx:         xxx
         ;; --------------------------------
-+       $3c864  xx xx xx:   xxx $3c739
++       $3c864  xx xx xx:   xxx RequestAttributeTable0Write
 ;;; --------------------------------
         $3c867  xx xx:      xxx #$xx
         $3c869  xx xx:      xxx #$xx
@@ -62453,9 +62492,9 @@ WriteMetatileAttributesForVerticalScroll
         ;; The lookup table is just ($b000 | y << 6) [b->13] but the 16-bit math
         ;; is awkward enough that presumably it's worth it (vs tya; asl*6; ...)
         $3ee00  xx:         xxx
-        $3ee01  xx xx xx:   xxx $3eeef,y
+        $3ee01  xx xx xx:   xxx TilesetBaseAddresses,y
         $3ee04  xx xx:      xxx $xx
-        $3ee06  xx xx xx:   xxx $3eef0,y
+        $3ee06  xx xx xx:   xxx TilesetBaseAddresses+1,y
         $3ee09  xx xx:      xxx $xx
         $3ee0b  xx xx:      xxx $xx
         $3ee0d  xx:         xxx
@@ -62502,9 +62541,9 @@ WriteMetatileAttributsForHorizontalScroll
         $3ee49  xx xx:      xxx #$xx
         $3ee4b  xx:         xxx
         $3ee4c  xx:         xxx
-        $3ee4d  xx xx xx:   xxx $3eeef,y
+        $3ee4d  xx xx xx:   xxx TilesetBaseAddresses,y
         $3ee50  xx xx:      xxx $xx
-        $3ee52  xx xx xx:   xxx $3eef0,y
+        $3ee52  xx xx xx:   xxx TilesetBaseAddresses+1,y
         $3ee55  xx xx:      xxx $xx
         $3ee57  xx xx:      xxx $xx
         $3ee59  xx:         xxx
@@ -62613,7 +62652,7 @@ LoadMetatileAttribute
         $3eee4  xx xx:        xxx - ; $3eede
 +       $3eee6  xx xx:      xxx #$xx
         $3eee8  xx:         xxx
-        $3eee9  xx xx xx:   xxx $3ef17,y
+        $3eee9  xx xx xx:   xxx AttributeQuads,y
         $3eeec  xx xx:      xxx $xx
         $3eeee  xx:         xxx
 ;;; --------------------------------
@@ -62886,10 +62925,10 @@ ValidateSaveFile1
         $3f0b3  xx xx:      xxx #$xx
 -       $3f0b5  xx xx xx:    xxx $xxxx,x
         $3f0b8  xx xx xx:    xxx $xxxx,x
-        $3f0bb  xx xx:       xxx + ; $3f0e7
+        $3f0bb  xx xx:       xxx CheckSaveFile1Replica1Checksum
         $3f0bd  xx xx xx:    xxx $xxxx,x
         $3f0c0  xx xx xx:    xxx $xxxx,x
-        $3f0c3  xx xx:       xxx + ; $3f0e7
+        $3f0c3  xx xx:       xxx CheckSaveFile1Replica1Checksum
         $3f0c5  xx xx xx:    xxx $xxxx,x
         $3f0c8  xx xx xx:    xxx $xxxx,x
         $3f0cb  xx xx:       xxx CheckSaveFile1Replica1Checksum
@@ -62977,6 +63016,7 @@ ValidateSaveFile2
         $3f170  xx xx:      xxx ResetSaveFile2
         $3f172  xx xx:      xxx ValidateCheckpointFile ; uncond
 ;;; --------------------------------
+CheckSaveFile2Replica1Checksum
         $3f174  xx xx:      xxx #$xx
         $3f176  xx xx xx:   xxx ChecksumSaveFile
         $3f179  xx xx xx:   xxx $xxxx
@@ -62986,6 +63026,8 @@ ValidateSaveFile2
         $3f182  xx xx xx:   xxx ReplicateSaveFile
         $3f185  xx xx:      xxx $xx
         $3f187  xx xx xx:   xxx $xxxx
+;;; --------------------------------
+CheckSaveFile2Replica2Checksum
         $3f18a  xx xx:      xxx #$xx
         $3f18c  xx xx xx:   xxx ChecksumSaveFile
         $3f18f  xx xx xx:   xxx $xxxx
@@ -63274,12 +63316,22 @@ HandleWarmBoot
         $3f3b3  xx xx xx:   xxx MainLoop
 ;;; --------------------------------
 ;;; The NMI handler does a number of things.
-;;; 1. Sometimes it's disabled entirely (see DisableNMI).
-;;; 2. If $60 is nonzero (see $3c73b), it simply clears the flag and exits.
-;;; 3. If $06 is nonzero (see $3f4cf), it sets $7 <- #$1 before exiting.
-;;; 4. If $9 is zero then we do an OAM DMA (from page $2xx).
-;;; 5. If $b != $a then we read $6200 for instructions to copy data from
-;;;    from $6000 into the PPU.
+; NOTE: Sometimes it's disabled entirely (see DisableNMI).
+;
+; NMI uses the following flags and values
+; $06 - Disable NMI and increment $07 if it was skipped
+; $60 - Disable NMI but dont increment $07 if it was skipped
+; $07 - Indicates if NMI was skipped
+; $09 - OAMDMA flag. Set to 0 to start OAMDMA.
+;         - inc every NMI, which tracks number of cycles since last OAM
+;         - Potentially a bug if it loops around but that likely never happens.
+; $02-$05 Viewport coords, copied into $7d8-$7db
+;         - If ScreenMode ($51) is EITHER 7 (Giant Insect Fight/Draygon 2) 
+;           or 9 (same fights but with text box for Not Enough MP etc) then
+;           it overwrites the just written value
+; $a,$b - Nametable write buffer pointers.
+;         - if $b != $a then we read $6200 for instructions to copy data from
+;           from $6000 into the PPU.
 HandleNMI
         $3f3b6  xx:         xxx
         $3f3b7  xx xx xx:    xxx $xxxx ; Clear the NMI flag

--- a/src/js/alloc.s
+++ b/src/js/alloc.s
@@ -69,9 +69,9 @@ JmpSeg38:
 ;;; Clear out some space in segment 13
 .segment "12", "13"
 
-RELOCATE_SEG38 [$aa16, $aa30) $a7d4 $a7d6
-RELOCATE [$abb4, $abea) $a054
-RELOCATE [$abea, $ac07) $a056
+; RELOCATE_SEG38 [$aa16, $aa30) $a7d4 $a7d6
+; RELOCATE [$abb4, $abea) $a054
+; RELOCATE [$abea, $ac07) $a056
 
 ;;; TODO - this does not work?
 ;; RELOCATE_SEG38 [$d659, $d6a8) $d575

--- a/src/js/cleanup.s
+++ b/src/js/cleanup.s
@@ -1,0 +1,416 @@
+
+;;; Cleanup NMI and NMI related flag usages
+.pushseg "fe", "ff"
+
+; Update the NMI Vector to point to our new handler
+.org $fffa
+.word (NMIHandler)
+
+.macro DISABLE_NMI
+lda #%10000000
+sta NmiDisable
+.endmacro
+
+.macro ENABLE_NMI
+lda #%00000000
+sta NmiDisable
+.endmacro
+
+.org $c436 ; EnableNMI
+  brk
+.org $c43e ; DisableNMI
+  brk
+; TODO use FREE_UNTIL after all are surely gone
+
+;;;---------------------------
+;;; WritePaletteDataToPpu
+; Changes from the original
+;  - Inlined to shave off jsr/rts (4 bytes and 12 cycles)
+;  - Removed unused loading palette by offset in x (saves 2 cycles from removing ldx #0)
+;  - Removed paranoid palette corruption fix. (saves 16 bytes and 20 cycles)
+.org $f8cb
+FREE_UNTIL $fa00
+
+;;;--------------------------
+;;; HandleNMI
+; Changes from Vanilla NMI handler
+; - Removes $60 as a flag. Just uses $06 as the NMI flag
+; - Uses freed zp ram to shave off extra cycles.
+;   - pha + pla = 7 cycles for a and 11 cycles for x,y. ld|st a/x/y is constant 6 cycles each.
+;     saves a total of 11 cycles every NMI
+; - Reworked the NMI disable path to be as fast as possible
+; - Removes the double scroll write on Draygon/Insect fights
+.org $f3b6
+FREE_UNTIL $f424
+.reloc
+NMIHandler:
+
+  .define NMI_A $0d ; Freed up from rewriting WriteNametableDataToPpu
+  .define NMI_X $60 ; Freed up from rewriting HandleNMI
+  .define NMI_Y $42 ; Probably unused?
+
+  bit NmiDisable
+  bpl @ContinueNMI
+    inc NmiSkipped
+    rti
+@ContinueNMI:
+  sta NMI_A
+  stx NMI_X
+  sty NMI_Y
+
+  lda PPUSTATUS
+  lda OamDisable
+  bne @SkipOAMDMA
+    ;; Do an OAM DMA
+    sta OAMADDR
+    lda #$02
+    sta OAMDMA
+
+    ;; If ScreenMode is 7 or 9, then copy $[8ace]3 into $07d[89ab] instead.
+    ;; This is the map position of object $13, likely the background boss
+    lda ScreenMode
+    cmp #$09
+    beq @CopyFromObjCoords
+    cmp #$07
+    bne @CopyFromStandardScroll
+      ; fallthrough
+@CopyFromObjCoords:
+      lda $83
+      sta $07d8
+      lda $a3
+      sta $07d9
+      lda $c3
+      sta $07da
+      lda $e3
+      sta $07db
+      jmp @SkipOAMDMA
+@CopyFromStandardScroll:
+      lda $02
+      sta $07d8
+      lda $03
+      sta $07d9
+      lda $04
+      sta $07da
+      lda $05
+      sta $07db
+      ; fallthrough
+@SkipOAMDMA:
+  ;; Back to the main line - always write nametables and palettes.
+  jsr WriteNametableDataToPpu
+  ; Inlined WritePaletteDataToPpu since it was only called from here.
+  ; Check if bit 7 is set, and skip palette update if it is
+  bit ScreenMode
+  bpl +
+    jmp @AfterPaletteUpdate
++
+  lda #$00
+  sta PPUMASK
+  lda PpuCtrlShadow
+  and #%11111011 ; #$fb
+  sta PPUCTRL
+  lda PPUSTATUS
+  lda #>VromPalettes ; $3f
+  sta PPUADDR
+  lda #<VromPalettes ; $00
+  sta PPUADDR
+  .repeat $20, i
+    lda $6140 + i
+    sta PPUDATA
+  .endrepeat
+  ; clear the latch just in case?
+  ; lda PPUSTATUS
+@AfterPaletteUpdate:
+  ;; Write PPUMASK from $01
+  lda PpuMaskShadow
+  sta PPUMASK
+  jsr ExecuteScreenMode
+  inc OamDisable ; flag OAMDMA complete by disabling it
+
+  ; Reload the register values and return
+  ldy NMI_Y
+  ldx NMI_X
+  lda NMI_A
+  rti
+
+
+.org $c739
+  brk
+FREE_UNTIL $c75c
+
+.reloc
+;; Changes from vanilla:
+; - Its slightly bigger to fit the new NMI flag in
+RequestAttributeTable0Write:
+  jsr DisableNMI
+  ldx NmtBufWriteOffset
+  lda #$23
+  sta $6200,x
+  lda #$c0
+  sta $6201,x
+  lda #$bf
+  sta $6202,x
+  lda #$00
+  sta $6203,x
+  txa
+  clc
+  adc #4
+  and #$1f
+  sta NmtBufWriteOffset
+  jmp EnableNMI
+
+;;;----------------------
+;;; WriteNametableDatatoPpu
+; Clean up some minor waste of cycles and make it relocatable
+; Changes from vanilla:
+;  - Use axs unoffical opcode to shave cycles off bulk copy
+;  - Removes the only reference to $0d so we can use that elsewhere
+.org $c67d
+  brk
+FREE_UNTIL $c72b
+.reloc
+WriteNametableDataToPpu:
+@ProcessNextEntry:
+  ldy NmtBufReadOffset
+  cpy NmtBufWriteOffset
+  beq @Exit
+  ;; Check bit :40 of $6200,x to see if we're writing a horizontal
+  ;; (clear) or vertical (set) strip to the nametable.  Fix the
+  ;; :04 bit of $0 and write it to PPUCTRL.
+  lda $6200,y
+  sta NmtBufTempValue
+  lda PpuCtrlShadow
+  and #%11111011 ; #~$04 disable vertical write if its enabled
+  bit NmtBufTempValue
+  bvc +
+   ora #%00000100 ; reenable vertical write if bit 6 was set
++ sta PPUCTRL
+  ;; Write the next 14 bits to PPUADDR (the :c0 bits are mirrored out)
+  lda NmtBufTempValue
+  sta PPUADDR
+  lda $6201,y
+  sta PPUADDR
+  lda $6202,y
+  pha ; number of bytes to write
+    ldx $6203,y ; offset into the $6000 page to write
+    ;; Mark this buffer as clear. If bit 7 of $6202 is set, then
+    ;; write from the memory in $6100 instead
+    lda #$ff
+    sta $6203,y
+  pla
+  bmi @WriteTwoRows
+  tay
+-   lda $6000,x
+    sta PPUDATA
+    inx
+    dey
+    bne -
+  ;; After writing one chunk, increment $a and loop to see
+  ;; if there's another chunk to write.
+  lda NmtBufReadOffset
+  clc
+  adc #$04
+  and #$1f
+  sta NmtBufReadOffset
+  lda NmtBufTempValue ; check bit 7 of $6202 to see if we loop
+  bmi @ProcessNextEntry
+@Exit:
+  rts
+@WriteTwoRows:
+  ldy #$08
+@BatchLoopCopy:
+.repeat 8, i
+    lda $6100 + i,x
+    sta PPUDATA
+.endrepeat
+    ; faster way to add 8 to x by using safe unofficial opcode `axs`
+    ; which calculates x = a & x - imm (#~8)
+    txa
+    .byte $cb, $f8 ; axs #$f8
+    dey
+    bne @BatchLoopCopy
+  ;; Bump the read offset
+  lda NmtBufReadOffset
+  clc
+  adc #$04
+  and #$1f
+  sta NmtBufReadOffset
+  rts
+
+;;; Various locations changed to no longer disable NMI
+;;; and use the following flag versions instead
+.reloc
+DisableNMI:
+  DISABLE_NMI
+  rts
+
+.reloc
+EnableNMI:
+  ENABLE_NMI
+  rts
+
+.reloc
+WaitForOAMDMA:
+- lda OamDisable
+  beq -
+  lda #$00
+  sta OamDisable
+  rts
+
+.org $c8b2
+  brk ; TODO remove after all are surely gone
+FREE_UNTIL $c8f0
+.reloc
+ImmediateWriteNametableDataToPpu:
+  DISABLE_NMI
+  jsr WriteNametableDataToPpu
+  ENABLE_NMI
+  rts
+
+;;--------------------------------
+;; Remove custom NMI disable (Note that this one didn't write to the shadow reg)
+.pushseg "10"
+.org $8ad7
+  jsr WriteNametableDataToPpu
+.org $8ada
+  jmp EnableNMI
+FREE_UNTIL $8aed
+
+.org $8ab0
+  jsr DisableNMI
+.popseg ; "10"
+
+.pushseg "12", "13"
+; WaitForOAMDMA_alt2
+.org $8084
+  jsr EnableNMI
+  jsr WaitForOAMDMA
+.org $8097
+  jsr WaitForOAMDMA
+.org $80a5
+  jsr WaitForOAMDMA
+.org $80c5
+  jsr WaitForOAMDMA
+.org $80d0
+  jsr WaitForOAMDMA
+.org $81a6
+  jsr DisableNMI
+.org $81d4
+  jsr EnableNMI
+.org $81f0
+  jsr DisableNMI
+.org $8247
+  jsr EnableNMI
+.org $8263
+  jsr DisableNMI
+.org $82a8
+  jsr EnableNMI
+  jsr WaitForOAMDMA
+.org $9fd2
+  jsr WaitForOAMDMA
+.org $a098
+  jsr DisableNMI
+.org $a0a1
+  jmp EnableNMI
+.org $a0c0
+  jsr WaitForOAMDMA
+.org $a2dd
+  jsr DisableNMI
+.org $a30b
+  jsr EnableNMI
+  jsr WaitForOAMDMA
+.org $a314
+  jsr DisableNMI
+.org $a345
+  jmp EnableNMI
+.org $a36e
+  jsr DisableNMI
+.org $a3a0
+  jsr EnableNMI
+.org $a47d
+  jsr DisableNMI
+.org $a4ad
+  jmp EnableNMI
+.org $a57f
+  jsr WaitForOAMDMA
+.org $a656
+  jsr WaitForOAMDMA
+.org $a690
+  jsr WaitForOAMDMA
+.org $a79b
+  jsr WaitForOAMDMA
+.org $a9b0
+  jsr WaitForOAMDMA
+  ; TODO This was relocated but my patch disagrees with it.
+.org $abb7
+  jsr WaitForOAMDMA
+
+.org $bb9a
+  jmp RequestAttributeTable0Write
+.org $bc01
+  jmp RequestAttributeTable0Write
+.org $be54
+  jmp RequestAttributeTable0Write
+
+.org $8174 ; DisableNMI_alt2 and then EnableNMI_alt2
+  brk ; TODO remove after all are surely gone
+FREE_UNTIL $8184
+.org $8198 ; WaitForOAMDMA
+  brk ; TODO remove after all are surely gone
+FREE_UNTIL $81a1
+.popseg ; "12", "13"
+
+.pushseg "1a", "1b"
+
+.org $8d1a
+  jsr DisableNMI
+.org $8d41
+  jsr ImmediateWriteNametableDataToPpu
+.org $8d46
+  jmp EnableNMI
+.org $8dd2
+  bne +
+    jsr ImmediateWriteNametableDataToPpu
++ jsr EnableNMI
+.org $8dad
+  jsr DisableNMI
+.org $8e90
+  jsr DisableNMI
+.org $8ebd
+  jsr ImmediateWriteNametableDataToPpu
+.org $8ec2
+  jmp EnableNMI
+.org $b835
+  jsr RequestAttributeTable0Write
+
+.popseg ; "1a", "1b"
+
+.org $c4be
+  jsr DisableNMI
+.org $c4e5
+  jsr ImmediateWriteNametableDataToPpu
+.org $c4e8
+  jsr EnableNMI
+.org $c864
+  jmp RequestAttributeTable0Write
+.org $de61
+  jsr RequestAttributeTable0Write
+.org $e89a
+  jsr RequestAttributeTable0Write
+.org $e965
+  jsr RequestAttributeTable0Write
+.org $ec2d
+  jsr DisableNMI
+.org $ec57
+  beq +
+    jmp EnableNMI
++ jmp ImmediateWriteNametableDataToPpu
+FREE_UNTIL $ec6c
+
+.org $ed3a
+  jsr DisableNMI
+.org $ed61
+  jmp EnableNMI
+
+;;------------------------------
+
+.popseg ; "fe", "ff"

--- a/src/js/init.s
+++ b/src/js/init.s
@@ -141,9 +141,33 @@ FREE "3d" [$a000, $c000)
 ;; .segment "3e"   :bank $3e :size $2000 :off $7c000 :mem $8000
 ;; .segment "3f"   :bank $3f :size $2000 :off $7e000 :mem $a000
 
+VromPalettes = $3f00
+PPUCTRL   = $2000
+PPUMASK   = $2001
+PPUSTATUS = $2002
+OAMADDR   = $2003
+OAMDATA   = $2004
+PPUSCROLL = $2005
+PPUADDR   = $2006
+PPUDATA   = $2007
+OAMDMA    = $4014
+
+; Workaround compiler issue that forces values set using `=`
+; to use absolute addressing instead of zp by using .define
+.define PpuCtrlShadow $00
+.define PpuMaskShadow $01
+
+.define NmiDisable $06 ; Set to 1 to disable NMI processing
+.define NmiSkipped $07 ; Set to $06 if NMI was skipped
+.define OamDisable $09 ; Set to $00 to have OAM run
+
+.define NmtBufReadOffset  $0a
+.define NmtBufWriteOffset $0b
+.define NmtBufTempValue   $0c
 
 ;;; Various global definitions.
-GameMode = $41
+.define GameMode   $41
+.define ScreenMode $51
 ObjectRecoil = $340
 ObjectHP = $3c0
 PlayerHP = $3c1
@@ -252,6 +276,7 @@ MainLoopItemGet            = $d3ff
 
 .segment "ff"                 ; 3e000
 RestoreBanksAndReturn         = $e756
+ExecuteScreenMode             = $f6ad
 ReadControllersWithDirections = $fe80
 DisplayNumber                 = $ffa9
 
@@ -330,7 +355,6 @@ FREE "fe" [$d654, $d659)
 ;;; Recovered from other item/trigger jumps (06/11, 0b, 0c, 0d, 0e, 0f,
 FREE "fe" [$d6d5, $d746)
 
-FREE "ff" [$f9ba, $fa00) ; first byte of DMC sample actually matters
 FREE "ff" [$fa01, $fe00) ; rts at 3fe00 is important
 FREE "ff" [$fe01, $fe16)
 FREE "ff" [$fe18, $fe78) ;; NOTE: 3fe2e might be safer than 3fe18

--- a/src/js/patch.ts
+++ b/src/js/patch.ts
@@ -442,6 +442,7 @@ async function shuffleInternal(rom: Uint8Array,
         new Tokenizer(flagFile, 'flags.s'),
         await tokenizer('init.s'),
         await tokenizer('alloc.s'),
+        await tokenizer('cleanup.s'),
         await tokenizer('preshuffle.s'),
         await tokenizer('postparse.s'),
         await tokenizer('postshuffle.s')));


### PR DESCRIPTION
In preparation for making stat tracking, I needed to make NMI always on. The reason is we want a timer to be as accurate as possible, so in order to do that we need to ensure that NMI is always running. We accomplish this by changing NMI to use a software flag in RAM for disabling NMI and changing every location that calls NMI to use the new relocatable NMI methods.

While I was at it, I rewrote the NMI function to save off several cycles by doing a few optimizations, as well as making the NMI disabled fast path as fast as possible.

I also consolidated every last instance of NMI disable/enable except for the closing credits. Just remembered I needed to do that while writing this.

And lastly, this has a few minor touch ups to the NMI write buffer. I free up an extra ZP slot, and save some cycles and bytes. 