### PR TITLE
Fix hp issues

### DIFF
--- a/src/js/preshuffle.s
+++ b/src/js/preshuffle.s
@@ -1188,6 +1188,9 @@ UpdateEnemyHPDisplayInternal:
     pha
       ldy CurrentEnemySlot
       bne @EnemyAlive
+        ;; If the HP slot is already clear, then skip redrawing anything
+        cpy PreviousEnemySlot
+        beq @EarlyExit
         ;; y is 0 at this point - zero everything out
         sty PreviousEnemySlot
         sty RecentEnemyCurrHPHi
@@ -1210,6 +1213,7 @@ UpdateEnemyHPDisplayInternal:
         jsr StageNametableWriteFromTable
         lda #ENEMY_NAME_VRAM_UPDATE
         jsr StageNametableWriteFromTable
+@EarlyExit:
     pla
     tay
   pla

--- a/src/js/rom/objects.ts
+++ b/src/js/rom/objects.ts
@@ -749,6 +749,20 @@ export class Objects extends EntityArray<ObjectData> {
       }
       a.assign('ENEMY_NAME_LENGTH', longestName);
       a.export('ENEMY_NAME_LENGTH');
+      a.segment('1a')
+      a.reloc('EnemyNameBlocklist')
+      a.label('EnemyNameBlocklist')
+      a.export('EnemyNameBlocklist')
+      let blockListLen = 0;
+      for (const obj of this) {
+        if (obj.hp > 0 && obj.displayName == '') {
+          a.byte(obj.id);
+          blockListLen++;
+        }
+      }
+      a.assign('ENEMY_NAME_BLOCKLIST_LEN', blockListLen);
+      a.export('ENEMY_NAME_BLOCKLIST_LEN');
+
       modules.push(a.module());
     }
     return modules;


### PR DESCRIPTION
- Add a tiny blocklist for enemies that have hp but no names
  - This prevents Sabera's orbs from attempting to be displayed
- Add a check that the last killed enemy was the last attacked enemy
  - This prevents Sabera's orbs from clearing out Sabera's name when they die
- Add a check to see if the enemy name is already cleared when clearing the slot
  - This is just for general safety

Also I prevent the HP bar from reclearing if it was already cleared. This greatly reduces the seamless transition lag