### PR TITLE
Move EXPAND_PRG to beginning of shuffle

### DIFF
--- a/src/asm/init.s
+++ b/src/asm/init.s
@@ -89,10 +89,12 @@ UPDATE_REFS target @ refs
 .segment "1c"   :bank $1c :size $2000 :off $38000 :mem $8000
 .segment "1d"   :bank $1d :size $2000 :off $3a000 :mem $a000
 ;;; Currently no good way to access the post-expanded 1e/1f
+.segment "1e"   :bank $1e :size $2000 :off $3c000 :mem $c000
+.segment "1f"   :bank $1f :size $2000 :off $3e000 :mem $e000
 
 ;;; Note: we moved these when we expanded the rom.
-.segment "fe"   :bank $1e :size $2000 :off $3c000 :mem $c000
-.segment "ff"   :bank $1f :size $2000 :off $3e000 :mem $e000
+.segment "fe"   :bank $1e :size $2000 :off $7c000 :mem $c000
+.segment "ff"   :bank $1f :size $2000 :off $7e000 :mem $e000
 
 ;;; Expanded rom segments??? consider doing these programmatically?
 ;;; Plane 4 - reserved for map data

--- a/src/asm/preshuffle.s
+++ b/src/asm/preshuffle.s
@@ -1859,7 +1859,7 @@ DynaShoot2:
 
 .endif
 
-;;.org $3c010
+;;.org $7c010
 ;;;; Adjusted inventory update - use level instead of sword
 ;;   ldy $0719  ; max charge level
 ;;   lda #$01
@@ -1875,7 +1875,7 @@ DynaShoot2:
 ;;   sta $03e1  ; player attack
 ;;   lda $0421  ; player level
 ;;   cpy #$0f   ; iron necklace - 1
-;;.org $3c02d   ; NOTE - MUST BE EXACT!!!!
+;;.org $7c02d   ; NOTE - MUST BE EXACT!!!!
 
 
 .segment "fe", "ff"
@@ -2254,7 +2254,7 @@ FREE_UNTIL $d280
 
 ;;; Convert a beq to a bcs for mimic spawns - any chest between $70 and $80
 ;;; will now spawn a mimic.
-;;; .org $3d3fd
+;;; .org $7d3fd
 ;;;   .byte $b0
 
 
@@ -2514,7 +2514,7 @@ PatchPrepareScreenMapRead:
 
 .ifdef _BUFF_DEOS_PENDANT
 ;;; Skip the check that the player is stationary.  We could also adjust
-;;; the speed by changing the mask at $3f02b from $3f to $1f to make it
+;;; the speed by changing the mask at $7f02b from $3f to $1f to make it
 ;;; faster, or $7f to slow it down.  Possibly we could start it at $7f and
 ;;; lsr if stationary, so that MP recovers quickly when still, but at half
 ;;; speed when moving?  We might want to consider how this plays with
@@ -2990,7 +2990,7 @@ TrainerStart:
   jsr TrainerGetItems
   lda #$04
   jsr TrainerGetItems
-  lda $6e ; NOTE: could just jmp $3d276 ?? but less hygeinic
+  lda $6e ; NOTE: could just jmp $7d276 ?? but less hygeinic
   pha
    lda #$1a
    jsr BankSwitch8k_8000 ; bank switch 8k 8000
@@ -3141,7 +3141,7 @@ SubtractEnemyHP:
   sbc #$00
   rts
 
-;;; Note: This is moved from $3db22, where we ran out of space.
+;;; Note: This is moved from $7db22, where we ran out of space.
 .reloc
 FinishEquippingConsumable:
     sbc #$1c
@@ -3198,10 +3198,10 @@ CheckToRedisplayUI:
   jmp CheckForPlayerDeath
 .endif
 
-;;; Repurpose $3e148 to skip loading NPCs and just reset pattern table.
-;;; The only difference from $3e144 is that $18 gets set to 1 instead of 0,
-;;; but this value is never read.  Start by changing all jumps to $3e148
-;;; to instead jump to $3e144.  Then we grab some space and have a nonzero
+;;; Repurpose $7e148 to skip loading NPCs and just reset pattern table.
+;;; The only difference from $7e144 is that $18 gets set to 1 instead of 0,
+;;; but this value is never read.  Start by changing all jumps to $7e148
+;;; to instead jump to $7e144.  Then we grab some space and have a nonzero
 ;;; value in $18 return early.
 .ifndef _WARP_FLAGS_TABLE ; Note: _WARP_FLAGS_TABLE patches this differently.
 .org $e6ff
@@ -3277,7 +3277,7 @@ GrantItemThenDisappear:  ; Used by Kensu in granting change (action 0c)
   jmp $d31f
 
 .reloc
-UseIvoryStatue:  ; Move bytes from $3d6ec
+UseIvoryStatue:  ; Move bytes from $7d6ec
   jsr $e144 ; LoadNpcDataForCurrentLocation
   ldx #$0f
   lda #$1a
@@ -3513,12 +3513,12 @@ Jmp11: ;;; More efficient version of `jsr $0010`, just `jsr Jmp11`
 .endif
 
 ;;; TODO - quick select items
-;; .org $3cb62
+;; .org $7cb62
 ;;   jsr ReadControllersAndUpdateStart
-;; .org $3d8ea
+;; .org $7d8ea
 ;;   jsr ReadControllersAndUpdateStart
 ;; 
-;; .org $3fa10
+;; .org $7fa10
 ;; ReadControllersAndUpdateStart:
 ;;   lda $43    ; Pressed buttons last frame
 ;;   and #$30   ; Start and Select
@@ -3548,9 +3548,9 @@ Jmp11: ;;; More efficient version of `jsr $0010`, just `jsr Jmp11`
 
 ;;; TODO - set up an in-game timer?
 ;;; Also display completion percent on end screen?
-;; .org $3f9f8
+;; .org $7f9f8
 ;; UpdateInGameTimer:
-;; .org $3f3b7
+;; .org $7f3b7
 ;;   nop
 ;;   jsr UpdateInGameTimer
 
@@ -3558,7 +3558,7 @@ Jmp11: ;;; More efficient version of `jsr $0010`, just `jsr Jmp11`
 ;;; The following patch fixes a crash where an IRQ right in the middle of
 ;;; loading NPCs can fail to correctly restore the bank select register
 ;;; $8000.  If the IRQ occurs exactly between selecting the bank and setting
-;;; the value (i.e. at $3c430..$3c432) and executes both MaybeUpdateMusic
+;;; the value (i.e. at $7c430..$7c432) and executes both MaybeUpdateMusic
 ;;; (which page-swaps, rewriting $50 to $8000 afterwards, but not restoring
 ;;; $50) and SelectCHRRomBanks (which restores $8000 to the clobbered $50)
 ;;; then the bank swap will fail.  In the case of this crash, it then reads

--- a/src/js/debugmode.js
+++ b/src/js/debugmode.js
@@ -21,7 +21,7 @@ export default ({
 
 // Fix the shaking issues by tweaking the delay times in IRQ callbacks.
 export const cheat = buildRomPatch(assemble(`
-.bank $3c000 $c000:$4000 ; fixed bank
+.bank $7c000 $c000:$4000 ; fixed bank
 .bank $1e000 $a000:$2000
 
 .org $1ff46
@@ -35,7 +35,7 @@ export const cheat = buildRomPatch(assemble(`
 
 // Fix the shaking issues by tweaking the delay times in IRQ callbacks.
 export const lime = buildRomPatch(assemble(`
-.bank $3c000 $c000:$4000 ; fixed bank
+.bank $7c000 $c000:$4000 ; fixed bank
 .bank $18000 $8000:$2000
 
 .org $19d22

--- a/src/js/depgraph.ts
+++ b/src/js/depgraph.ts
@@ -195,7 +195,7 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
                                   .key();
   const ballOfWater           = item(0x09, 'Ball of Water')
                                   .weight(5)
-                                  .direct('Rage', 0x3d337)
+                                  .direct('Rage', 0x7d337)
                                   .npcSpawn(0xc3)
                                   .key();
   const blizzardBracelet      = item(0x0a, 'Blizzard Bracelet')
@@ -247,7 +247,7 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
   const warpBoots             = item(0x24, 'Warp Boots').consumable();
   const statueOfOnyx          = item(0x25, 'Statue of Onyx')
                                   .chest('Cordel grass')
-                                  .invisible(0x3e3a2)
+                                  .invisible(0x7e3a2)
                                   .key();
   const opelStatue            = item(0x26, 'Opel Statue')
                                   .consumable()
@@ -264,7 +264,7 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
                                   .dialog(0x38, undefined, 4)
                                   .key();
   const gasMask               = item(0x29, 'Gas Mask')
-                                  .direct('Akahana in Brynmaer', 0x3d7fe)
+                                  .direct('Akahana in Brynmaer', 0x7d7fe)
                                   .npcSpawn(0x16, 0x18)
                                   .key();
   const powerRing             = item(0x2a, 'Power Ring').chest().bonus();
@@ -286,7 +286,7 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
                                          'Speed Boots' :
                                          'Leather Boots').chest().bonus();
   const shieldRing            = item(0x30, 'Shield Ring')
-                                  .direct('Akahana in waterfall cave', 0x3d2af)
+                                  .direct('Akahana in waterfall cave', 0x7d2af)
                                   // Redundant? just use ~034
                                   //.npcSpawn(0x16, 0x57, 1)
                                   .bonus();
@@ -352,11 +352,11 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
   //                                .fixed();
   const lovePendant           = item(0x3b, 'Love Pendant')
                                   .chest('Underground channel')
-                                  .invisible(0x3e3aa)
+                                  .invisible(0x7e3aa)
                                   .key();
   const kirisaPlant           = item(0x3c, 'Kirisa Plant')
                                   .chest('Kirisa meadow')
-                                  .invisible(0x3e3a6)
+                                  .invisible(0x7e3a6)
                                   .key();
   const ivoryStatue           = item(0x3d, 'Ivory Statue')
                                   .bossDrop('Karmine', 0x09)
@@ -364,7 +364,7 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
                                   .key();
   const bowOfMoon             = item(0x3e, 'Bow of Moon')
                                   .fromPerson('Aryllis', 0x23) // not actually used???
-                                  .direct(0x3d6e8)
+                                  .direct(0x7d6e8)
                                   .dialog(0x23, undefined, 1)
                                   .key();
   const bowOfSun              = item(0x3f, 'Bow of Sun')
@@ -378,13 +378,13 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
   const refresh               = magic(0x41, 'Refresh')
                                   .fromPerson('Zebu at windmill', 0x5e)
                                   .requireUnique()
-                                  .direct(0x3d711)
+                                  .direct(0x7d711)
                                   // NOTE: moved from offset 2 because we rearranged
                                   // zebu to always spawn windmill guard
                                   .dialog(0x5e, 0x10, 3)
                                   .trigger(0xb4, 1);
   const paralysis             = magic(0x42, 'Paralysis')
-                                  .direct('Zebu at Mt. Sabre summit', 0x3d655)
+                                  .direct('Zebu at Mt. Sabre summit', 0x7d655)
                                   .requireUnique()
                                   // TODO - require defeating kelbesque?
                                   .trigger(0x8d)
@@ -397,22 +397,22 @@ export const generate = (flags: FlagSet = new FlagSet(), rom?: Rom): WorldGraph 
                                   .fromPerson('Tornel on Mt. Sabre', 0x5f)
                                   .dialog(0x5f, 0x21, 0);
   const recover               = magic(0x45, 'Recover')
-                                  .direct('Asina in Portoa', 0x3d1f9);
+                                  .direct('Asina in Portoa', 0x7d1f9);
                                   // NOTE: no need for second slot because
                                   // recover does not have an ItemGet normally.
   const barrier               = magic(0x46, 'Barrier')
-                                  .direct('Asina on Angry sea', 0x3d6d9)
+                                  .direct('Asina on Angry sea', 0x7d6d9)
                                   .requireUnique()
                                   .trigger(0x84, 0);
   const change                = magic(0x47, 'Change')
-                                  .direct('Kensu in Swan', 0x3d6de)
+                                  .direct('Kensu in Swan', 0x7d6de)
                                   // NOTE: 74 and 7e are redundant, not sure why.
                                   // Ideally we could delete one of them entirely?
                                   .npcSpawn(0x74, 0xf1, 1)
                                   .npcSpawn(0x7e, 0xf1, 1);
   const flight                = magic(0x48, 'Flight')
                                   .weight(15)
-                                  .direct('Kensu in Draygonia Fortress', 0x3d18f);
+                                  .direct('Kensu in Draygonia Fortress', 0x7d18f);
                                   // See recover - no need for second slot.
   const fruitOfPowerVampire2  = fruitOfPower
                                   .bossDrop('Vampire 2', 0x0c, 0x61)

--- a/src/js/pass/deterministic.ts
+++ b/src/js/pass/deterministic.ts
@@ -97,7 +97,7 @@ export function deterministicPreParse(prg: Uint8Array): void {
   prg[0x1aa86] = 0xfe; // trigger -> unused spawn
 
   // TODO - these are transitional until we move the logic elsewhere
-  write(prg, 0x3d6d5,
+  write(prg, 0x7d6d5,
         0x25, 0x29,  // 25 statue of onyx use -> 29 gas mask
         0x39, 0x3a,  // 39 glowing lamp use -> 3a statue of gold
         0x3b, 0x47,  // 3b love pendant use -> 47 change
@@ -528,7 +528,7 @@ function fogLampNotRequired(rom: Rom, flags: FlagSet) {
 /**
  * Remove timer spawns from all chests.  Mimics have already been
  * renumbered to be unique (pre-parse).  Note that the renumbering
- * requires an assembly change ($3d3fd in preshuffle.s).
+ * requires an assembly change ($7d3fd in preshuffle.s).
  */
 function fixChests(rom: Rom): void {
   for (const loc of rom.locations) {

--- a/src/js/patch.ts
+++ b/src/js/patch.ts
@@ -237,11 +237,16 @@ export async function shuffle(rom: Uint8Array,
 
   //rom = watchArray(rom, 0x85fa + 0x10);
   if (EXPAND_PRG && rom.length < 0x80000) {
-    const newRom = new Uint8Array(rom.length + 0x40000);
-    newRom.subarray(0, 0x40010).set(rom.subarray(0, 0x40010));
-    newRom.subarray(0x80010).set(rom.subarray(0x40010));
-    newRom[4] <<= 1;
-    rom = newRom;
+    if (rom.length < 0x80000) {
+        const newRom = new Uint8Array(rom.length + 0x40000);
+        newRom.subarray(0, 0x40010).set(rom.subarray(0, 0x40010));
+        newRom.subarray(0x80010).set(rom.subarray(0x40010));
+        newRom[4] <<= 1;
+        rom = newRom;
+    }
+    
+    const prg = rom.subarray(0x10);
+    prg.subarray(0x7c000, 0x80000).set(prg.subarray(0x3c000, 0x40000));
   }
 
   deterministicPreParse(rom.subarray(0x10)); // TODO - trainer...
@@ -506,10 +511,6 @@ async function shuffleInternal(rom: Uint8Array,
 
   parsed.writeData();
 
-  if (EXPAND_PRG) {
-    const prg = rom.subarray(0x10);
-    prg.subarray(0x7c000, 0x80000).set(prg.subarray(0x3c000, 0x40000));
-  }
   // TODO - optional flags can possibly go here, but MUST NOT use parsed.prg!
   patchGraphics(rom, spriteReplacements);
   return [rom, crc];

--- a/src/js/rom/boss.ts
+++ b/src/js/rom/boss.ts
@@ -23,6 +23,11 @@ const BOSS_OBJECT_ADDRESS = [
   [0x0b3f1, true], // vampire 2               cc [1]
 ] as const;
 
+// NOTE: This appears to be currently unused code, and as such, I wasn't sure
+//       whether to update the Mado 1 address above when moving the EXPAND_PRG
+//       process. When returning to this code, make sure to double check that.
+//       -CodeGorilla, 10/23/2022
+
 export function shuffleBosses(rom: Rom, random: Random) {
   // TODO - this doesn't actually work, but if it did, we'd need to
   // store it properly in the Rom object, rather than writing it

--- a/src/js/rom/bosses.ts
+++ b/src/js/rom/bosses.ts
@@ -64,7 +64,7 @@ export class Bosses implements Iterable<Boss> {
     sword: 1,
   });
   readonly Mado1 = new Boss(this, {
-    address: 0x3d820,
+    address: 0x7d820,
     flag: this.rom.flags.Mado1,
     kill: 0x5,
     shuffled: true,

--- a/src/js/rom/constraint.ts
+++ b/src/js/rom/constraint.ts
@@ -157,7 +157,7 @@ export class Constraint {
     // be more flexible if we rewrote that offset, but then we wouldn't
     // get both versions of Kensu so easily.
     // NOTE: after we get the chest, we could reset the patterns by
-    //       shunting $3d458
+    //       shunting $7d458
     return new Constraint([new Set([0x51]), ALL, ALL, ALL], [], 0);
   }
 

--- a/src/js/rom/flags.ts
+++ b/src/js/rom/flags.ts
@@ -202,7 +202,7 @@ export class Flags {
   // unused 042
   // unused 0x043 = dialogProgression('Oak');
   0x044 = obsolete(0x107); // check: ball of fire / insect
-  RescuedChild = fixed(0x045, TRACK); // hardcoded $3e7d5
+  RescuedChild = fixed(0x045, TRACK); // hardcoded $7e7d5
   UsedInsectFlute = fixed(0x046); // custom-added $6488:40
   RescuedLeafElder = movable(0x047);
   0x048 = dialogProgression('Treasure hunter embarked');
@@ -218,7 +218,7 @@ export class Flags {
   GivenStatueToAkahana = movable(0x050); // give it back if unsuccessful?
   0x051 = obsolete(0x146); // check: barrier / angry sea
   TalkedToDwarfMother = movable(0x052, TRACK);
-  LeadingChild = fixed(0x053, TRACK); // hardcoded $3e7c4 and following
+  LeadingChild = fixed(0x053, TRACK); // hardcoded $7e7c4 and following
   // unused 054
   0x055 = dialogProgression('Zebu rescued');
   0x056 = dialogProgression('Tornel rescued');


### PR DESCRIPTION
Moves the EXPAND_PRG step from the very end of shuffle_internal to the beginning of shuffle, immediately after making space in the byte array representing the raw ROM.  Additionally, changes all hardcoded references to addresses in the 0x3c000 to 0x4000 range to the 0x7c000 to 0x80000, to correspond to the new, expanded memory.

Tested on one seed, full cleared, flags were Ds Edrstux Rost Vms

There are a handful of files where the only thing I touched were comments; I went ahead an updated them just to hopefully avoid further confusion, but if for some reason they need to stay the way they were, let me know.