### PR TITLE
Fix bad reference in Portoa Queen's dialog when shuffling trade-ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,14 +20,3 @@ node_modules
 tsconfig.tsbuildinfo
 npm-debug.log
 .tsc.out
-.project
-bin/.github/workflows/publish.yml
-bin/.npmignore
-bin/.project
-bin/.travis.yml
-bin/BUILD.md
-bin/CHANGELOG.md
-bin/debug
-bin/deploy_key.enc
-bin/README.md
-bin/TODO

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,14 @@ node_modules
 tsconfig.tsbuildinfo
 npm-debug.log
 .tsc.out
+.project
+bin/.github/workflows/publish.yml
+bin/.npmignore
+bin/.project
+bin/.travis.yml
+bin/BUILD.md
+bin/CHANGELOG.md
+bin/debug
+bin/deploy_key.enc
+bin/README.md
+bin/TODO

--- a/src/js/pass/shuffletrades.ts
+++ b/src/js/pass/shuffletrades.ts
@@ -9,7 +9,7 @@ export function shuffleTrades(rom: Rom, flags: FlagSet, random: Random) {
   const {
     items: {StatueOfOnyx, FogLamp, LovePendant,
             KirisaPlant, IvoryStatue},
-    locations: {Swan_DanceHall},
+    locations: {Swan_DanceHall, PortoaPalace_ThroneRoom},
     npcs: {KensuInSwan},
   } = rom;
 
@@ -54,7 +54,7 @@ export function shuffleTrades(rom: Rom, flags: FlagSet, random: Random) {
   rom.npcs[0xc3].localDialogs.get(-1)![0].condition = 0x200 | rage.id;
   if (rom.spoiler) rom.spoiler.addTrade(rage.id, rage.messageName, 'Rage');
   // Portoa queen 38 takes the same sword as Rage
-  rom.npcs.PortoaQueen.localDialogs.get(-1)![3].condition = 0x200 | rage.id;
+  rom.npcs.PortoaQueen.dialog(PortoaPalace_ThroneRoom)[1].condition = 0x200 | rage.id;
 
   const tornel = rom.items[random.nextInt(4) * 2 + 6];
   for (const ds of rom.npcs[0x5f].localDialogs.values()) {


### PR DESCRIPTION
shuffletrades.ts was trying to reference a piece of dialog that no longer exists, after a change (commit c408b95, Oct. 14th 2022) was made to split the Portoa Queen's dialog across two locations, causing an error any time a seed was generated with Wt on. This updates the reference to point to the correct line of dialog.  I based these changes on similar changes made to fixdailog.ts to fix a similar bug from the same source.

Also, ignore the changes to .gitignore.  I was trying to submit something so that my local workspace would stop trying to add a bunch of extra files to my changes, but I didn't realize GitHub wouldn't let me make a PR out of a single commit, and instead would try to merge all of the differences.  GitHub sucks. :)

(Okay, it probably doesn't actually suck, I'm just used to different source control tools and have a lot to learn.)