### PR TITLE
Fix Zebu's dialog in Zebu's Cave

### DIFF
--- a/src/js/pass/deterministic.ts
+++ b/src/js/pass/deterministic.ts
@@ -1105,10 +1105,10 @@ function preventNpcDespawns(rom: Rom, opts: FlagSet): void {
   Zebu.localDialogs.set(ZebuCave.id, [
     LocalDialog.of(~flags.TalkedToZebuInCave.id,
                    [0x00, 0x1a], [flags.TalkedToZebuInCave.id]),
-    LocalDialog.of(flags.LeafVillagersRescued.id, [0x00, 0x1d]),
-    LocalDialog.of(flags.LeafAbduction.id, [0x00, 0x1c]), // 038 leaf attacked
     LocalDialog.of(flags.ZebuAtWindmill.id, [0x00, 0x1d]), // 039 learned refresh
     LocalDialog.of(flags.UsedWindmillKey.id, [0x00, 0x1b, 0x03]), // => refresh
+    LocalDialog.of(flags.LeafVillagersRescued.id, [0x00, 0x1d]),
+    LocalDialog.of(flags.LeafAbduction.id, [0x00, 0x1c]), // 038 leaf attacked
     LocalDialog.of(~0, [0x00, 0x1d]),
   ]);
   // Don't despawn on getting barrier


### PR DESCRIPTION
In a rare case, Wa seeds could break because the logic expects the player to get [Refresh] from Zebu directly after using the Windmill Key, instead of getting it from the invisible trigger in Wind Valley. This specifically caused problems when the player was forced to trigger the Leaf Kidnapping first, as that dialog would take precedence over the dialog to grant the item. The proposed fix is to just reorder the dialog so that the check for having used the Windmill Key always comes first.