### PR TITLE
Fix Draygon 2 requirements so that Story Mode is properly considered.

### DIFF
--- a/src/js/logic/world.ts
+++ b/src/js/logic/world.ts
@@ -1404,7 +1404,7 @@ export class World {
     }
     if (boss === this.rom.bosses.Insect) {
       extra.push(this.rom.flags.InsectFlute.c, this.rom.flags.GasMask.c);
-    } else if (boss === this.rom.bosses.Draygon2) {
+    } else if (boss === this.rom.bosses.Draygon2 && !this.flagset.noBowMode()) {
       extra.push(this.rom.flags.BowOfTruth.c);
     }
     if (this.flagset.guaranteeRefresh()) {

--- a/src/js/patch.ts
+++ b/src/js/patch.ts
@@ -283,6 +283,8 @@ async function shuffleInternal(rom: Uint8Array,
   if (flags.shuffleMimics()) shuffleMimics(parsed, flags, random);
   if (flags.shuffleMonsters()) shuffleMonsters(parsed, flags, random);
 
+  if (flags.storyMode()) storyMode(parsed);
+  
   // This wants to go as late as possible since we need to pick up
   // all the normalization and other handling that happened before.
   const world = new World(parsed, flags);
@@ -338,8 +340,6 @@ async function shuffleInternal(rom: Uint8Array,
     parsed.items.MedicalHerb.value = 80;
     parsed.items.FruitOfPower.value = 56;
   }
-
-  if (flags.storyMode()) storyMode(parsed);
 
   // Do this *after* shuffling palettes
   if (flags.blackoutMode()) blackoutMode(parsed);


### PR DESCRIPTION
By moving the call to the storyMode function in patch.ts to just before the World object is constructed, the spawn requirements are converted into logical requirements. This has technically been wrong for a while, but it hasn't mattered until this branch, which introduces the possibility of Tower being logically required.