### PR TITLE
Fix queen requirement

### DIFF
--- a/src/js/logic/world.ts
+++ b/src/js/logic/world.ts
@@ -211,7 +211,6 @@ export class World {
     this.addItemCheck([start], and(GlowingLamp, BrokenStatue),
                       RepairedStatue.id, {lossy: true, unique: true});
     
-
     // Add shops
     for (const shop of this.rom.shops) {
       // leaf and shyron may not always be accessible, so don't rely on them.
@@ -837,10 +836,6 @@ export class World {
     // It seems like probably marking it as (x-1, y-1) .. (x, y) makes the
     // most sense, with the caveat that triggers shifted right by a half
     // tile should go from x .. x+1 instead.
-    
-    if (location == this.rom.locations.UndergroundChannel) {
-        console.log(`Underground Channel trigger: ${spawn.id}`);
-    }
     
     // TODO - consider checking trigger's action: $19 -> push-down message
 

--- a/src/js/logic/world.ts
+++ b/src/js/logic/world.ts
@@ -180,7 +180,7 @@ export class World {
         BreakStone, BreakIce, BreakIron,
         BrokenStatue, BuyHealing, BuyWarp,
         ClimbWaterfall, ClimbSlope8, ClimbSlope9, ClimbSlope10,
-        CrossPain, CurrentlyRidingDolphin,
+        CrossPain, Crystalis, CurrentlyRidingDolphin,
         Flight, FlameBracelet, FormBridge,
         GasMask, GlowingLamp,
         InjuredDolphin,
@@ -190,7 +190,7 @@ export class World {
         RabbitBoots, Refresh, RepairedStatue, RescuedChild,
         ShellFlute, ShieldRing,
         ShootingStatue, ShootingStatueSouth, StomSkip, StormBracelet,
-        Sword, SwordOfFire, SwordOfThunder, SwordOfWater, SwordOfWind, Crystalis,
+        Sword, SwordOfFire, SwordOfThunder, SwordOfWater, SwordOfWind,
         TornadoBracelet, TravelSwamp, TriggerSkip,
         UsedBowOfMoon, UsedBowOfSun,
         WildWarp,
@@ -210,6 +210,7 @@ export class World {
     this.addCheck([enterOak], and(LeadingChild), [RescuedChild.id]);
     this.addItemCheck([start], and(GlowingLamp, BrokenStatue),
                       RepairedStatue.id, {lossy: true, unique: true});
+    
 
     // Add shops
     for (const shop of this.rom.shops) {
@@ -836,14 +837,18 @@ export class World {
     // It seems like probably marking it as (x-1, y-1) .. (x, y) makes the
     // most sense, with the caveat that triggers shifted right by a half
     // tile should go from x .. x+1 instead.
-
+    
+    if (location == this.rom.locations.UndergroundChannel) {
+        console.log(`Underground Channel trigger: ${spawn.id}`);
+    }
+    
     // TODO - consider checking trigger's action: $19 -> push-down message
 
     // TODO - pull out this.recordTriggerTerrain() and this.recordTriggerCheck()
     const trigger = this.rom.trigger(spawn.id);
     if (!trigger) throw new Error(`Missing trigger ${spawn.id.toString(16)}`);
 
-    const requirements = this.filterRequirements(trigger.conditions);
+    let requirements = this.filterRequirements(trigger.conditions);
     let antiRequirements = this.filterAntiRequirements(trigger.conditions);
 
     const tile = TileId.from(location, spawn);
@@ -852,6 +857,9 @@ export class World {
     const checks = [];
     for (const flag of trigger.flags) {
       const f = this.flag(flag);
+      if (f == this.rom.flags.EnteredUndergroundChannel) {
+        requirements = Requirement.meet(requirements, this.rom.flags.TalkedToFortuneTeller.r);
+      }
       if (f?.logic.track) {
         checks.push(f.id);
       }


### PR DESCRIPTION
This adds a logical requirement to the underground channel trigger to have visited the Portoa fortune teller first.  This prevents the player from softlocking a seed by dismissing the Portoa queen when she has a logically relevant item by guaranteeing that the fortune teller is available to bring her back. Note that this is only a *logical* requirement, not a *physical* one, so sneaking past the throne room guard works as expected even if you never choose to talk to the fortune teller.